### PR TITLE
Implement selection of entire Creative Type card on choice, and adjust css

### DIFF
--- a/src/containers/Create/Create.css
+++ b/src/containers/Create/Create.css
@@ -1,0 +1,24 @@
+.create-start-entire-card {
+  width: 70%;
+  margin: 1rem;
+  padding-bottom: 1.5rem;
+  text-align: left;
+}
+
+.create-start-card-selected {
+  border: 0 solid #1890ff;
+  box-shadow: 0 0 10px rgba(24, 144, 255, 0.5);
+}
+
+.create-start-card-selected .ant-card-body {
+  background-color: #b6b6b6;
+  border-radius: 8px;
+}
+
+.create-start-card {
+  border: none;
+}
+
+.large-icons .ant-radio-button-wrapper {
+  border: none;
+}

--- a/src/containers/Create/Create.css
+++ b/src/containers/Create/Create.css
@@ -5,20 +5,16 @@
   text-align: left;
 }
 
-.create-start-card-selected {
+.create-start-entire-card .ant-radio-button-wrapper-checked .ant-card-body {
+  background-color: #b6b6b6;
+  border-radius: 8px;
   border: 0 solid #1890ff;
   box-shadow: 0 0 10px rgba(24, 144, 255, 0.5);
 }
 
-.create-start-card-selected .ant-card-body {
-  background-color: #b6b6b6;
-  border-radius: 8px;
-}
-
-.create-start-card {
+.create-start-entire-card .ant-radio-button-wrapper-checked {
   border: none;
 }
-
-.large-icons .ant-radio-button-wrapper {
+.create-start-entire-card .ant-radio-button-wrapper {
   border: none;
 }

--- a/src/containers/Create/CreateStart.tsx
+++ b/src/containers/Create/CreateStart.tsx
@@ -51,13 +51,7 @@ export const CreateStart = () => {
           <Row gutter={16}>
             <Col span={6}>
               <Radio value={CARD_TYPES.NEW}>
-                <Card
-                  className={
-                    templateType === CARD_TYPES.NEW
-                      ? "create-start-card-selected"
-                      : "create-start-card"
-                  }
-                >
+                <Card style={{ border: "none" }}>
                   <img width={120} height={120} src="/img/TA.png" />
                   New Item
                 </Card>
@@ -65,13 +59,7 @@ export const CreateStart = () => {
             </Col>
             <Col span={6}>
               <Radio value={CARD_TYPES.COMPARISON}>
-                <Card
-                  className={
-                    templateType === CARD_TYPES.COMPARISON
-                      ? "create-start-card-selected"
-                      : "create-start-card"
-                  }
-                >
+                <Card style={{ border: "none" }}>
                   <img width={120} height={120} src="/img/TB.png" />
                   Comparison
                 </Card>
@@ -79,13 +67,7 @@ export const CreateStart = () => {
             </Col>
             <Col span={6}>
               <Radio value={CARD_TYPES.FEATURE}>
-                <Card
-                  className={
-                    templateType === CARD_TYPES.FEATURE
-                      ? "create-start-card-selected"
-                      : "create-start-card"
-                  }
-                >
+                <Card style={{ border: "none" }}>
                   <img width={120} height={120} src="/img/TC.png" />
                   Feature
                 </Card>
@@ -93,13 +75,7 @@ export const CreateStart = () => {
             </Col>
             <Col span={6}>
               <Radio value={CARD_TYPES.SALE}>
-                <Card
-                  className={
-                    templateType === CARD_TYPES.SALE
-                      ? "create-start-card-selected"
-                      : "create-start-card"
-                  }
-                >
+                <Card style={{ border: "none" }}>
                   <img width={120} height={120} src="/img/TD.png" />
                   Sale
                 </Card>

--- a/src/containers/Create/CreateStart.tsx
+++ b/src/containers/Create/CreateStart.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { ReactEventHandler, useContext } from "react";
 import {
   Button,
   Card,
@@ -11,8 +11,16 @@ import {
   theme,
 } from "antd";
 import { CreateContext } from "./CreateContainer";
+import "./Create.css";
 
 const { Text, Title, Link } = Typography;
+
+const CARD_TYPES = {
+  NEW: "new",
+  COMPARISON: "comparison",
+  FEATURE: "feature",
+  SALE: "sale",
+};
 
 export const CreateStart = () => {
   const {
@@ -22,53 +30,76 @@ export const CreateStart = () => {
     setTargetUrl,
     handleStart,
   } = useContext(CreateContext);
+
+  const handleTemplateTypeChange = (e: any) => {
+    setTemplateType(e.target.value);
+  };
+
   return (
     <>
       {/* <Text style={{ fontSize: "80px" }}>ECのProduct Imageを</Text>
       <br />
-      <Text style={{ fontSize: "80px" }}>一瞬で創作</Text>
-      <p></p> */}
-      <p></p>
-      <Card style={{ width: "70%" }} title="Creative Type">
+      <Text style={{ fontSize: "80px" }}>一瞬で創作</Text>*/}
+      <Card className="create-start-entire-card" title="Creative Type">
         <Radio.Group
           size="large"
-          buttonStyle="solid"
+          optionType="button"
           className="large-icons"
           value={templateType}
-          onChange={(e) => {
-            setTemplateType(e.target.value);
-          }}
+          onChange={handleTemplateTypeChange}
         >
           <Row gutter={16}>
             <Col span={6}>
-              <Radio value="new">
-                <Card>
+              <Radio value={CARD_TYPES.NEW}>
+                <Card
+                  className={
+                    templateType === CARD_TYPES.NEW
+                      ? "create-start-card-selected"
+                      : "create-start-card"
+                  }
+                >
                   <img width={120} height={120} src="/img/TA.png" />
                   New Item
                 </Card>
               </Radio>
             </Col>
             <Col span={6}>
-              <Radio value="comparison">
-                <Card>
+              <Radio value={CARD_TYPES.COMPARISON}>
+                <Card
+                  className={
+                    templateType === CARD_TYPES.COMPARISON
+                      ? "create-start-card-selected"
+                      : "create-start-card"
+                  }
+                >
                   <img width={120} height={120} src="/img/TB.png" />
                   Comparison
                 </Card>
               </Radio>
             </Col>
             <Col span={6}>
-              <Radio value="feature">
-                <Card>
-                  {" "}
+              <Radio value={CARD_TYPES.FEATURE}>
+                <Card
+                  className={
+                    templateType === CARD_TYPES.FEATURE
+                      ? "create-start-card-selected"
+                      : "create-start-card"
+                  }
+                >
                   <img width={120} height={120} src="/img/TC.png" />
                   Feature
                 </Card>
               </Radio>
             </Col>
             <Col span={6}>
-              <Radio value="sale">
-                <Card>
-                  {" "}
+              <Radio value={CARD_TYPES.SALE}>
+                <Card
+                  className={
+                    templateType === CARD_TYPES.SALE
+                      ? "create-start-card-selected"
+                      : "create-start-card"
+                  }
+                >
                   <img width={120} height={120} src="/img/TD.png" />
                   Sale
                 </Card>


### PR DESCRIPTION
Creative Type選択時にカード全体を選択する機能を実装、およびcssの調整
- Remove the radio button (ラジオボタンを削除)
- Change the card background to gray when selected (カードが選択されたときに背景をグレーに変更)
- Remove the card border (カードの境界線を削除)
- Adjust CSS for better layout and design (CSSを調整)