### PR TITLE
Implemented sorting by create_dt, and added update_dt functionality

### DIFF
--- a/src/hooks/useCanvasData.ts
+++ b/src/hooks/useCanvasData.ts
@@ -45,6 +45,8 @@ export const initialCanvasData: Canvas = {
   },
   canvas_data: "",
   thumbnail: "",
+  create_dt: null as unknown as Date,
+  update_dt: null as unknown as Date,
 };
 
 export interface CanvasDataInterface {
@@ -176,12 +178,17 @@ export const useCanvasData = (canvasIdProp: string): CanvasDataInterface => {
     // if (!(canvas.canvas_data as string).startsWith("https")) {
     //   canvas.canvas_data = "";
     // }
-    setCanvasData(canvas);
+    const updateDate = new Date();
+    setCanvasData({ ...canvas, update_dt: updateDate });
     try {
       canvas &&
-        (await setDoc(doc(db, "canvases", canvas.uid), canvas, {
-          merge: true,
-        }));
+        (await setDoc(
+          doc(db, "canvases", canvas.uid),
+          { ...canvas, update_dt: updateDate },
+          {
+            merge: true,
+          }
+        ));
     } catch (e: any) {
       console.error(e);
     }

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -55,7 +55,10 @@ const Home = () => {
 
   const handleNewCanvas = async () => {
     initialCanvasData.user_id = user_id;
-    const docRef = await addDoc(collection(db, "canvases"), initialCanvasData);
+    const docRef = await addDoc(collection(db, "canvases"), {
+      ...initialCanvasData,
+      create_dt: new Date(),
+    });
     navigate(`/canvas/${docRef.id}`);
   };
 
@@ -64,12 +67,26 @@ const Home = () => {
     loadCanvases();
   };
 
+  const handleSort = (a, b) => {
+    if (a.uid === "new") return -1;
+    if (b.uid === "new") return 1;
+
+    if (!a.create_dt) return 1;
+    if (!b.create_dt) return -1;
+
+    if (a.create_dt?.toDate().getTime() > b.create_dt?.toDate().getTime())
+      return -1;
+    if (a.create_dt?.toDate().getTime() < b.create_dt?.toDate().getTime())
+      return 1;
+    return 0;
+  };
+
   return (
     <>
       <h1>Home</h1>
       <List
         grid={{ gutter: 16, column: 4 }}
-        dataSource={canvases}
+        dataSource={canvases.sort(handleSort)}
         renderItem={(canvas) =>
           canvas.uid === "new" ? (
             <List.Item>


### PR DESCRIPTION
Implemented sorting by create_dt, and added update_dt functionality
create_dtでのソート機能を実装し、update_dtを追加
説明:
create_dtスタンプがない項目は比較せず、create_dtがある項目の後ろに配置するよう実装
Implemented to place items without a create_dt timestamp in front