### PR TITLE
Editor: Display spinners during template loading and after selection until the loads are complete

### DIFF
--- a/src/components/CanvasPane/CanvasPane.tsx
+++ b/src/components/CanvasPane/CanvasPane.tsx
@@ -3,7 +3,7 @@ import {
   FabricJSCanvas,
   useFabricJSEditor,
 } from "../../hooks/useFabricJSEditor";
-import { Button, Input } from "antd";
+import { Button, Input, Spin } from "antd";
 import { SketchPicker } from "react-color";
 import "./CanvasPane.css";
 import { CanvasContext } from "@pages/Canvas/Canvas";
@@ -22,6 +22,7 @@ const CanvasPane = () => {
     onReady,
   } = useContext(CanvasContext);
   const [text, setText] = useState("");
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const handleSaveData = () => {
     saveTimer.current && clearTimeout(saveTimer.current);
@@ -66,9 +67,25 @@ const CanvasPane = () => {
     };
   }, []);
 
+  useEffect(() => {
+    if (canvasImageData !== "") setIsLoading(false);
+  }, [canvasImageData]);
+
   return (
     <>
       {editor ? <div></div> : <>Loading...</>}
+      {isLoading && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "100vh",
+          }}
+        >
+          <Spin size="large" />
+        </div>
+      )}
       <FabricJSCanvas className="synapse-canvas" onReady={onReady} />
     </>
   );

--- a/src/containers/Create/CreateList.tsx
+++ b/src/containers/Create/CreateList.tsx
@@ -1,6 +1,6 @@
 import { fabric } from "fabric";
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { List, Card, Col, Row } from "antd";
+import { List, Card, Col, Row, Spin } from "antd";
 import { Button, Input, Layout, Typography, theme } from "antd";
 import { CreateContext } from "./CreateContainer";
 import { Link, useNavigate, useParams } from "react-router-dom";
@@ -37,6 +37,7 @@ export const CreateList = () => {
   const canvasFileRef = canvasId ? ref(storage, canvasDataName) : null;
   const alreadyReading = useRef<boolean>(false);
   const ImageStore = useRef<templateImage[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const getEmbeddedTemplate: ({
     template_id,
@@ -47,6 +48,7 @@ export const CreateList = () => {
   );
 
   useEffect(() => {
+    setIsLoading(true);
     if (!alreadyReading.current) {
       alreadyReading.current = true;
       if (templates.length > 0) {
@@ -75,6 +77,7 @@ export const CreateList = () => {
       console.log([...ImageStore.current]);
     }
     alreadyReading.current = true;
+    setIsLoading(false);
   };
 
   const handleClick = async (templateImage: string) => {
@@ -94,6 +97,18 @@ export const CreateList = () => {
 
   return (
     <>
+      {isLoading && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "100vh",
+          }}
+        >
+          <Spin size="large" />
+        </div>
+      )}
       <div style={{ width: "500px", textAlign: "right" }}>
         <br />
         {ImageStore.current.length >= 1 ? (


### PR DESCRIPTION
Display spinners during template loading and after selection until the loads are complete
テンプレートの読み込み中と選択後の読み込み中に、スピナーを表示する
