### PR TITLE
Replace useRef with useState for loading state to control spinner visibility

### DIFF
--- a/src/components/CanvasPane/CanvasPane.tsx
+++ b/src/components/CanvasPane/CanvasPane.tsx
@@ -20,10 +20,9 @@ const CanvasPane = () => {
     editor,
     selectedObjects,
     onReady,
+    isLoading,
   } = useContext(CanvasContext);
   const [text, setText] = useState("");
-  // ToDo: This doesn't work when clicking '新規作成'
-  // const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const handleSaveData = () => {
     saveTimer.current && clearTimeout(saveTimer.current);
@@ -68,16 +67,9 @@ const CanvasPane = () => {
     };
   }, []);
 
-  // ToDo: This doesn't work when clicking '新規作成'
-  // useEffect(() => {
-  //   if (canvasImageData !== "") setIsLoading(false);
-  // }, [canvasImageData]);
-
   return (
     <>
       {editor ? <div></div> : <>Loading...</>}
-
-      {/* ToDo: This doesn't work when clicking '新規作成'
       {isLoading && (
         <div
           style={{
@@ -89,7 +81,7 @@ const CanvasPane = () => {
         >
           <Spin size="large" />
         </div>
-      )} */}
+      )}
       <FabricJSCanvas className="synapse-canvas" onReady={onReady} />
     </>
   );

--- a/src/hooks/useCanvasData.ts
+++ b/src/hooks/useCanvasData.ts
@@ -56,6 +56,7 @@ export interface CanvasDataInterface {
   saveCanvasData: (canvas: any) => void;
   saveCanvasImageData: (canvas_data: string) => void;
   saveThumbnail: (editor: FabricJSEditor) => void;
+  isLoading: boolean;
   error: boolean;
 }
 
@@ -67,7 +68,7 @@ export const useCanvasData = (canvasIdProp: string): CanvasDataInterface => {
   const [canvasId, setCanvasId] = useState<string>(canvasIdProp);
   const [canvasData, setCanvasData] = useState<Canvas>(initialCanvasData);
   const [canvasImageData, setCanvasImageData] = useState<string>("");
-  const loading = useRef<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const loaded = useRef<boolean>(true);
   const unsub = useRef<() => void>(() => {});
   const canvasDataRef = useRef<Canvas>(initialCanvasData);
@@ -82,9 +83,8 @@ export const useCanvasData = (canvasIdProp: string): CanvasDataInterface => {
   };
 
   useEffect(() => {
-    if (!loading.current && canvasId) {
-      loading.current = true;
-
+    if (!isLoading && canvasId) {
+      setIsLoading(true);
       (async () => {
         if (canvasIdProp === "new") {
           initialCanvasData.user_id = user_id;
@@ -119,7 +119,7 @@ export const useCanvasData = (canvasIdProp: string): CanvasDataInterface => {
         } else {
           setError(true);
         }
-        loading.current = false;
+        setIsLoading(false);
       })();
     }
     return () => {
@@ -201,6 +201,7 @@ export const useCanvasData = (canvasIdProp: string): CanvasDataInterface => {
     saveCanvasData,
     saveCanvasImageData,
     saveThumbnail,
+    isLoading,
     error,
   };
 };

--- a/src/pages/Canvas/Canvas.tsx
+++ b/src/pages/Canvas/Canvas.tsx
@@ -48,6 +48,7 @@ const Canvas = () => {
     saveCanvasData,
     saveCanvasImageData,
     saveThumbnail,
+    isLoading,
     error,
   } = useCanvasData(canvasIdParam ?? "");
   const {
@@ -116,6 +117,7 @@ const Canvas = () => {
         saveCanvasData,
         saveCanvasImageData,
         saveThumbnail,
+        isLoading,
         error,
         selectedObjects,
         editor,


### PR DESCRIPTION
ローディング状態の管理とスピナーの表示制御のために、useRefをuseStateに置き換える